### PR TITLE
moved to alpine and  npm installs to bash file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,9 @@
 
 	"extensions": [
 		"VisualStudioExptTeam.vscodeintellicode",
-		"react-proptypes-generate",
-		"eamodio.gitlens"
+		"suming.react-proptypes-generate",
+		"eamodio.gitlens",
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode"
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,20 @@
- FROM debian:latest
-
-ARG NODE_VERSION='14.17.5'
+FROM node:14-alpine
 
 # Install:
-# - npm / n / yarn 
-# - netcat (required by CI build)
-RUN apt-get update && \
-    apt-get -y install ripgrep less curl netcat npm && \
-    npm install -g n && \
-    n ${NODE_VERSION}
-
-RUN npm install -g yarn
-RUN npm i json-server
-RUN npm i cypress
-RUN npm i cypress-cucumber-preprocessor
-RUN npm i cypress-react-selector
-RUN npm i @testing-library/cypress
-RUN npm i @testing-library/react
-RUN npm i @testing-library/jest-dom
-RUN npm i react-query
-RUN npm i react-toastify
-RUN RUN npm i create-react-app
-RUN npx create-react-app my-app --template typescript
+RUN apk update && \
+   apk add --no-cache curl bash git netcat-openbsd
 	
 # Install Git command line completion
 RUN curl https://raw.githubusercontent.com/git/git/v2.20.1/contrib/completion/git-completion.bash -o ~/.git-completion.bash && \
     echo "[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash" >> ~/.bashrc
 
+# Setup create-react-app script to run in .devcontainer postCreateCommand
 RUN mkdir /.initScripts
 COPY --chown=root:root create-react-app.sh /.initScripts/
 RUN chmod o+x /.initScripts/create-react-app.sh
 
+# Set the work directory
 RUN mkdir /projects
-# Set the directory
 WORKDIR /projects
 
 EXPOSE 8080

--- a/create-react-app.sh
+++ b/create-react-app.sh
@@ -3,3 +3,13 @@ read varname
 echo Running npx create-react-app $varname --template typescript
 npx create-react-app $varname --template typescript
 
+# Install dev and testing tools
+npm i json-server
+npm i cypress
+npm i cypress-cucumber-preprocessor
+npm i cypress-react-selector
+npm i @testing-library/cypress
+npm i @testing-library/react
+npm i @testing-library/jest-dom
+npm i react-query
+npm i react-toastify


### PR DESCRIPTION
The build was taking a long time.  The first attempt was to move the application name question up in the build process.  This was difficult and I decided to move the base image to alpine and move the npm install to the create-react-app.sh file so they would install after the application name question was asked.

The result is that the application name question is asked pretty early and most of the install work happens after that.